### PR TITLE
Agregar default URL para permitir usar una misma url para las llamadas

### DIFF
--- a/DREAM Lab Frontend/src/Global/Auth.js
+++ b/DREAM Lab Frontend/src/Global/Auth.js
@@ -7,7 +7,7 @@ export async function loginAction({ formData }) {
   const user = formData.get("user");
   const password = formData.get("password");
   // Llamar a la API para validar las credenciales
-  return post("http://localhost:3000/authUsuario", {
+  return post("authUsuario", {
     usuario: user,
     contrasena: password,
   })

--- a/DREAM Lab Frontend/src/Global/Database.js
+++ b/DREAM Lab Frontend/src/Global/Database.js
@@ -15,7 +15,7 @@ function MyComponent() {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const result = await get('https://api.example.com/data', () => setIsLoading(false), () => setIsLoading(false));
+        const result = await get('data', () => setIsLoading(false), () => setIsLoading(false));
         setData(result);
       } catch (error) {
         console.error('An error occurred:', error);
@@ -48,7 +48,7 @@ function MyComponent() {
   useEffect(() => {
     const postData = async () => {
       try {
-        const result = await post('https://api.example.com/data', { name: 'John' }, () => setIsLoading(false), () => setIsLoading(false));
+        const result = await post('data', { name: 'John' }, () => setIsLoading(false), () => setIsLoading(false));
         setData(result);
       } catch (error) {
         console.error('An error occurred:', error);
@@ -70,6 +70,8 @@ function MyComponent() {
 export default MyComponent;
 */
 
+const defaultURL = "http://localhost:3000/";
+
 async function apiRequest(
   method,
   url,
@@ -80,7 +82,7 @@ async function apiRequest(
   try {
     const response = await axios({
       method,
-      url,
+      url: defaultURL + url,
       data,
       headers: {
         "Content-Type": "application/json",

--- a/DREAM Lab Frontend/src/Global/ProtectedRoutes.jsx
+++ b/DREAM Lab Frontend/src/Global/ProtectedRoutes.jsx
@@ -29,7 +29,7 @@ function ProtectedRoutes({ children }) {
   useEffect(() => {
     // Llamada a la API para validar el token
     async function validateToken() {
-      const data = await post("http://localhost:3000/authToken", {
+      const data = await post("authToken", {
         token: getFromLocalStorage("token") || "",
       });
 


### PR DESCRIPTION
## Descripción de cambios
- Guardar en una variable la primer parte del url para solo tener que poner la llamada a la función y no el url de azure o de localhost

## Lista de Verificación
- [X] Revisé a detalle mi código.
- [X] Si se trata de una característica esencial, he realizado las pruebas correspondientes.
- [X] Agregué comentarios a mi código.
- [X] Mis cambios no generan ninguna alerta.
