### PR TITLE
Agregar routing para permitir hacer refresh

### DIFF
--- a/dream-lab-frontend/staticwebapp.config.json
+++ b/dream-lab-frontend/staticwebapp.config.json
@@ -1,0 +1,6 @@
+{
+    "navigationFallback": {
+        "rewrite": "/index.html",
+        "exclude": ["*.{css, scss, js, png, gif, ico, jpg, svg}"]
+    }
+}


### PR DESCRIPTION
## Descripción de cambios
- Debido a que se está utilizando client-side-routing, cuando cambiamos entre páginas, está usando el mismo archivo html mientras se cambia la ruta del url. Sin embargo, si refresacamos la página, se intenta cargar el HTML de la ruta en la que estamos, la cual no exist. Con este cambio, siempre se apuntará a index.html, exceptuando por algunos archivos que se excluyen como imágenes, archivos de estilo, etc.

## Lista de Verificación
- [X] Revisé a detalle mi código.
- [X] Si se trata de una característica esencial, he realizado las pruebas correspondientes.
- [X] Agregué comentarios a mi código.
- [X] Mis cambios no generan ninguna alerta.
