### PR TITLE
Fix session storage

### DIFF
--- a/dream-lab-frontend/src/pages/HomePage/HomePage.jsx
+++ b/dream-lab-frontend/src/pages/HomePage/HomePage.jsx
@@ -247,7 +247,6 @@ function HomePage() {
     };
 
     useEffect(() => {
-        console.log("HomePage: useEffect: Clearing sessionStorage");
         multiClearSessionStorage([
             "horaInicio",
             "horaInicioIsoString",

--- a/dream-lab-frontend/src/pages/HomePage/HomePage.jsx
+++ b/dream-lab-frontend/src/pages/HomePage/HomePage.jsx
@@ -5,9 +5,7 @@ import RecommendationsCarousel from "./components/RecommendationsCarousel/Recomm
 import RecomendacionesInvalidas from "./components/RecomendacionesInvalidas/RecomendacionesInvalidas.jsx";
 import Navbar from "src/GlobalComponents/NavBar/NavBar.jsx"; // Import the Navbar component
 import "./HomePage.css";
-import {
-    multiClearSessionStorage
-} from "src/utils/Storage.js";
+import { multiClearSessionStorage } from "src/utils/Storage.js";
 
 import { get, API_URL } from "src/utils/ApiRequests.js";
 import Detalles from "./components/Detalles/Detalles.jsx";
@@ -113,7 +111,6 @@ function HomePage() {
     const [showRecommendations, setShowRecommendations] = useState(false);
     const [showInvalidNotice, setShowInvalidNotice] = useState(false);
 
-
     const [detallesVisible, setDetallesVisible] = useState(false);
     const [imageID, setImageID] = useState(null); // Nuevo estado para imageID
     const detallesRef = useRef(null);
@@ -121,7 +118,6 @@ function HomePage() {
     const [salasBD, setSalasBD] = useState(null);
     const [isLoading, setIsLoading] = useState(true);
     const [isSalaClicked, setIsSalaClicked] = useState(false);
-
 
     // Función para mostrar Detalles
     const mostrarDetalles = () => {
@@ -251,6 +247,7 @@ function HomePage() {
     };
 
     useEffect(() => {
+        console.log("HomePage: useEffect: Clearing sessionStorage");
         multiClearSessionStorage([
             "horaInicio",
             "horaInicioIsoString",
@@ -263,9 +260,14 @@ function HomePage() {
             "idExperiencia",
             "idSala",
             "reservType",
-            "materials"
+            "materials",
+            "competidores",
+            "cupos",
+            "formattedDate",
+            "formattedTime",
+            "horaCorte",
+            "nameSalaExperiencia",
         ]);
-
     }, []);
 
     useEffect(() => {

--- a/dream-lab-frontend/src/pages/Profile/components/NameCard/NameCard.jsx
+++ b/dream-lab-frontend/src/pages/Profile/components/NameCard/NameCard.jsx
@@ -23,7 +23,6 @@ function NameCard({ nombre, handleLogroArtista }) {
 
     useEffect(() => {
         get(`perfil/logros/${getFromLocalStorage("user")}`).then((response) => {
-            console.log(response);
             setLogrosObtenidos(response.logros);
             setLogroSeleccionado({
                 idLogro: response.configuracionLogro[0].idLogro,

--- a/dream-lab-frontend/src/pages/Profile/components/NameCard/components/BotonLogroPerfil/components/SelectorLogro/SelectorLogro.jsx
+++ b/dream-lab-frontend/src/pages/Profile/components/NameCard/components/BotonLogroPerfil/components/SelectorLogro/SelectorLogro.jsx
@@ -42,7 +42,6 @@ function SelectorLogro({
                     colorPreferido: colorSeleccionado,
                 }
             );
-            console.log(response);
             await handleLogroArtista(10);
             setRefresh((prev) => !prev);
             onOpenChange();

--- a/dream-lab-frontend/src/pages/SelectorSala/components/TextoNombreSala/TextoNombreSala.jsx
+++ b/dream-lab-frontend/src/pages/SelectorSala/components/TextoNombreSala/TextoNombreSala.jsx
@@ -23,7 +23,6 @@ const TextoNombreSala = () => {
             get(`salas/${id}`)
                 .then((result) => {
                     setNombreSala(result[0].nombre);
-                    saveToSessionStorage("nameSalaExperiencia", nombreSala);
                 })
                 .catch((error) => {
                     console.error("An error occurred:", error);
@@ -32,7 +31,6 @@ const TextoNombreSala = () => {
             get(`experiencias/${id}`)
                 .then((result) => {
                     setNombreExperiencia(result[0].nombre);
-                    saveToSessionStorage("nameSalaExperiencia", nombreExperiencia);
                 })
                 .catch((error) => {
                     console.error("An error occurred:", error);
@@ -47,6 +45,14 @@ const TextoNombreSala = () => {
                 });
         }
     }, []);
+
+    useEffect(() => {
+        if (type === "sala") {
+            saveToSessionStorage("nameSalaExperiencia", nombreSala);
+        } else {
+            saveToSessionStorage("nameSalaExperiencia", nombreExperiencia);
+        }
+    }, [nombreSala, nombreExperiencia]);
 
     return (
         <>

--- a/dream-lab-frontend/src/pages/Videowall/components/ReservacionesVideowall/components/CarouselReservaciones/CarouselReservaciones.jsx
+++ b/dream-lab-frontend/src/pages/Videowall/components/ReservacionesVideowall/components/CarouselReservaciones/CarouselReservaciones.jsx
@@ -32,7 +32,6 @@ function CarouselReservaciones() {
     // Obtener los datos para las tarjetas de reservaciones
     useEffect(() => {
         get("videowall/reservaciones").then((res) => {
-            console.log(res);
             res = res.map((item) => {
                 let horaInicioDate = new Date(item.horaInicio);
                 let horaFinDate = new Date(item.horaInicio);
@@ -51,7 +50,6 @@ function CarouselReservaciones() {
 
                 return { ...item, horaInicio, horaFin };
             });
-            console.log(res);
             setReservaciones(res);
         });
     }, []);

--- a/dream-lab-frontend/src/pages/Videowall/components/ReservacionesVideowall/components/CarouselReservaciones/components/ReservationCard.jsx
+++ b/dream-lab-frontend/src/pages/Videowall/components/ReservacionesVideowall/components/CarouselReservaciones/components/ReservationCard.jsx
@@ -14,7 +14,6 @@ function ReservationCard({
     icono,
     colorPreferido,
 }) {
-    console.log(icono);
     return (
         <div className="rc-container">
             <div className="rc-image-container">

--- a/dream-lab-frontend/src/utils/Storage.js
+++ b/dream-lab-frontend/src/utils/Storage.js
@@ -1,3 +1,9 @@
+/* LOCAL STORAGE */
+
+export function existsInLocalStorage(key) {
+    return localStorage.getItem(key) !== null;
+}
+
 export function saveToLocalStorage(key, value) {
     localStorage.setItem(key, value);
 }
@@ -10,8 +16,20 @@ export function removeFromLocalStorage(key) {
     localStorage.removeItem(key);
 }
 
-export function existsInLocalStorage(key) {
-    return localStorage.getItem(key) !== null;
+export function multiClearLocalStorage(keys) {
+    keys.forEach((key) => {
+        removeFromLocalStorage(key);
+    });
+}
+
+export function clearLocalStorage() {
+    localStorage.clear();
+}
+
+/* SESSION STORAGE */
+
+export function existsInSessionStorage(key) {
+    return sessionStorage.getItem(key) !== null;
 }
 
 export function saveToSessionStorage(key, value) {
@@ -23,36 +41,22 @@ export function getFromSessionStorage(key) {
 }
 
 export function removeFromSessionStorage(key) {
-    if (existsInLocalStorage(key)) {
-        sessionStorage.removeItem(key);
-    }
-}
-
-export function existsInSessionStorage(key) {
-    return sessionStorage.getItem(key) !== null;
-}
-
-export function clearStorages() {
-    localStorage.clear();
-    sessionStorage.clear();
-}
-
-export function clearLocalStorage() {
-    localStorage.clear();
-}
-
-export function clearSessionStorage() {
-    sessionStorage.clear();
-}
-
-export function multiClearLocalStorage(keys) {
-    keys.forEach((key) => {
-        removeFromLocalStorage(key);
-    });
+    sessionStorage.removeItem(key);
 }
 
 export function multiClearSessionStorage(keys) {
     keys.forEach((key) => {
         removeFromSessionStorage(key);
     });
+}
+
+export function clearSessionStorage() {
+    sessionStorage.clear();
+}
+
+/* LOCAL STORAGE & SESSION STORAGE */
+
+export function clearStorages() {
+    localStorage.clear();
+    sessionStorage.clear();
 }


### PR DESCRIPTION
## Descripción de cambios
- Corregir funciones de session y local storage: Función de multiClearSessionStorage checaba si la llave estaba en el local storage, por lo que nunca borraba nada.
- Agregar llaves faltantes al useEffect de Home para que se borren todos los datos.
- Corregir asignación de nombreExperienciaSala que anteriormente tomaba de un useState que todavía no se le asignaba un valor. Se dividió el proceso de obtener datos de la API y asignar al useState, y el proceso de guardar el useState en el session Storage.

## Lista de Verificación
- [X] Agregué comentarios a mi código.
- [X] Mis cambios no generan ninguna alerta.
- [ ] El flujo desarrollado cuenta con pruebas de Cypress.
- [ ] Todas las pruebas de Cypress pasaron.
- [ ] Construí y previsualicé la aplicación y la nueva funcionalidad se despliega correctamente.
