### PR TITLE
Fix selector logros

### DIFF
--- a/dream-lab-frontend/cypress/e2e/personalizacionLogros.cy.js
+++ b/dream-lab-frontend/cypress/e2e/personalizacionLogros.cy.js
@@ -1,0 +1,394 @@
+describe("Pruebas de personalización de los logros", () => {
+    beforeEach(() => {
+        cy.intercept("GET", "perfil/test", {
+            body: {
+                recordsets: [
+                    [
+                        {
+                            prioridad: 55,
+                            nombre: "test",
+                            apellidoP: "test",
+                            apellidoM: "test",
+                            apodo: "Ancient Soul",
+                            iconoURL:
+                                "https://dreamlabstorage.blob.core.windows.net/logros/AncientSoul.webp",
+                        },
+                    ],
+                    [
+                        {
+                            idReservacion: 6,
+                            idSala: 1,
+                            idExperiencia: 2,
+                            idMesa: 2,
+                            estatus: 4,
+                            horaInicio: "1970-01-01T12:00:00.000Z",
+                            duracion: 3,
+                            fecha: "2024-01-05T00:00:00.000Z",
+                            numPersonas: 3,
+                            nombre_experiencia: "Cisco Experience",
+                            nombre_sala: "Electric Garage",
+                        },
+                        {
+                            idReservacion: 7,
+                            idSala: 2,
+                            idExperiencia: 3,
+                            idMesa: 3,
+                            estatus: 4,
+                            horaInicio: "1970-01-01T09:00:00.000Z",
+                            duracion: 2,
+                            fecha: "2024-02-10T00:00:00.000Z",
+                            numPersonas: 4,
+                            nombre_experiencia: "Game jam event",
+                            nombre_sala: "Dimension Forge",
+                        },
+                        {
+                            idReservacion: 8,
+                            idSala: 3,
+                            idExperiencia: 1,
+                            idMesa: 4,
+                            estatus: 4,
+                            horaInicio: "1970-01-01T15:00:00.000Z",
+                            duracion: 1,
+                            fecha: "2024-03-15T00:00:00.000Z",
+                            numPersonas: 5,
+                            nombre_experiencia: "Hackers Event",
+                            nombre_sala: "New Horizons",
+                        },
+                        {
+                            idReservacion: 9,
+                            idSala: 2,
+                            idExperiencia: null,
+                            idMesa: null,
+                            estatus: 4,
+                            horaInicio: "1970-01-01T11:00:00.000Z",
+                            duracion: 3,
+                            fecha: "2024-05-03T00:00:00.000Z",
+                            numPersonas: null,
+                            nombre_experiencia: null,
+                            nombre_sala: "Dimension Forge",
+                        },
+                        {
+                            idReservacion: 10,
+                            idSala: 11,
+                            idExperiencia: null,
+                            idMesa: null,
+                            estatus: 4,
+                            horaInicio: "1970-01-01T12:00:00.000Z",
+                            duracion: 2,
+                            fecha: "2024-05-14T00:00:00.000Z",
+                            numPersonas: null,
+                            nombre_experiencia: null,
+                            nombre_sala: "Beyond-Digits",
+                        },
+                        {
+                            idReservacion: 11,
+                            idSala: 11,
+                            idExperiencia: null,
+                            idMesa: null,
+                            estatus: 4,
+                            horaInicio: "1970-01-01T11:00:00.000Z",
+                            duracion: 2,
+                            fecha: "2024-05-14T00:00:00.000Z",
+                            numPersonas: null,
+                            nombre_experiencia: null,
+                            nombre_sala: "Beyond-Digits",
+                        },
+                        {
+                            idReservacion: 12,
+                            idSala: 10,
+                            idExperiencia: null,
+                            idMesa: null,
+                            estatus: 4,
+                            horaInicio: "1970-01-01T12:00:00.000Z",
+                            duracion: 3,
+                            fecha: "2024-05-19T00:00:00.000Z",
+                            numPersonas: null,
+                            nombre_experiencia: null,
+                            nombre_sala: "Biometrics Flexible Hall",
+                        },
+                        {
+                            idReservacion: 13,
+                            idSala: 4,
+                            idExperiencia: null,
+                            idMesa: null,
+                            estatus: 4,
+                            horaInicio: "1970-01-01T12:00:00.000Z",
+                            duracion: 1,
+                            fecha: "2024-05-29T00:00:00.000Z",
+                            numPersonas: null,
+                            nombre_experiencia: null,
+                            nombre_sala: "Deep Net",
+                        },
+                        {
+                            idReservacion: 14,
+                            idSala: 9,
+                            idExperiencia: null,
+                            idMesa: null,
+                            estatus: 4,
+                            horaInicio: "1970-01-01T10:00:00.000Z",
+                            duracion: 1,
+                            fecha: "2024-05-23T00:00:00.000Z",
+                            numPersonas: null,
+                            nombre_experiencia: null,
+                            nombre_sala: "War Headquarters",
+                        },
+                        {
+                            idReservacion: 15,
+                            idSala: 1,
+                            idExperiencia: null,
+                            idMesa: null,
+                            estatus: 3,
+                            horaInicio: "1970-01-01T13:00:00.000Z",
+                            duracion: 3,
+                            fecha: "2024-05-16T00:00:00.000Z",
+                            numPersonas: null,
+                            nombre_experiencia: null,
+                            nombre_sala: "Electric Garage",
+                        },
+                        {
+                            idReservacion: 16,
+                            idSala: 7,
+                            idExperiencia: null,
+                            idMesa: null,
+                            estatus: 3,
+                            horaInicio: "1970-01-01T13:00:00.000Z",
+                            duracion: 2,
+                            fecha: "2024-05-16T00:00:00.000Z",
+                            numPersonas: null,
+                            nombre_experiencia: null,
+                            nombre_sala: "Hack-Battlefield",
+                        },
+                        {
+                            idReservacion: 17,
+                            idSala: 1,
+                            idExperiencia: null,
+                            idMesa: null,
+                            estatus: 3,
+                            horaInicio: "1970-01-01T14:00:00.000Z",
+                            duracion: 2,
+                            fecha: "2024-05-06T00:00:00.000Z",
+                            numPersonas: null,
+                            nombre_experiencia: null,
+                            nombre_sala: "Electric Garage",
+                        },
+                        {
+                            idReservacion: 18,
+                            idSala: 4,
+                            idExperiencia: null,
+                            idMesa: null,
+                            estatus: 3,
+                            horaInicio: "1970-01-01T10:00:00.000Z",
+                            duracion: 2,
+                            fecha: "0002-05-03T00:00:00.000Z",
+                            numPersonas: null,
+                            nombre_experiencia: null,
+                            nombre_sala: "Deep Net",
+                        },
+                        {
+                            idReservacion: 19,
+                            idSala: 7,
+                            idExperiencia: null,
+                            idMesa: null,
+                            estatus: 3,
+                            horaInicio: "1970-01-01T11:00:00.000Z",
+                            duracion: 3,
+                            fecha: "2024-05-03T00:00:00.000Z",
+                            numPersonas: null,
+                            nombre_experiencia: null,
+                            nombre_sala: "Hack-Battlefield",
+                        },
+                    ],
+                    [
+                        {
+                            idLogro: 1,
+                            nombre: "Big Dreamer",
+                            descripcion:
+                                "Reserva 50 veces algún espacio del D.R.E.A.M. Lab.",
+                            prioridadOtorgada: 1,
+                            color: "#AFB7FF",
+                            iconoURL:
+                                "https://dreamlabstorage.blob.core.windows.net/logros/BigDreamer.webp",
+                            valorMax: 50,
+                        },
+                        {
+                            idLogro: 2,
+                            nombre: "Independent Learner",
+                            descripcion:
+                                "Completa 20 experiencias autodirigidas.",
+                            prioridadOtorgada: 1,
+                            color: "#C0A2FF",
+                            iconoURL:
+                                "https://dreamlabstorage.blob.core.windows.net/logros/IndependentLearner.webp",
+                            valorMax: 20,
+                        },
+                        {
+                            idLogro: 3,
+                            nombre: "Robot Expert",
+                            descripcion:
+                                "Asiste a 5 eventos dentro del “Electric Garage”.",
+                            prioridadOtorgada: 1,
+                            color: "#78C2F8",
+                            iconoURL:
+                                "https://dreamlabstorage.blob.core.windows.net/logros/RobotExpert.webp",
+                            valorMax: 5,
+                        },
+                        {
+                            idLogro: 4,
+                            nombre: "Testing Champion",
+                            descripcion:
+                                "Reserva y asiste 5 veces a la sala “Testing Land”.",
+                            prioridadOtorgada: 1,
+                            color: "#FF87E5",
+                            iconoURL:
+                                "https://dreamlabstorage.blob.core.windows.net/logros/TestingChampion.webp",
+                            valorMax: 5,
+                        },
+                        {
+                            idLogro: 5,
+                            nombre: "Ancient Soul",
+                            descripcion:
+                                "Reserva y asiste 3 veces a la sala “Graveyard”.",
+                            prioridadOtorgada: 1,
+                            color: "#98A6B6",
+                            iconoURL:
+                                "https://dreamlabstorage.blob.core.windows.net/logros/AncientSoul.webp",
+                            valorMax: 3,
+                        },
+                        {
+                            idLogro: 6,
+                            nombre: "Visionary",
+                            descripcion:
+                                "Reserva y asiste 2 veces a la “Sala VR”.",
+                            prioridadOtorgada: 1,
+                            color: "#FF6073",
+                            iconoURL:
+                                "https://dreamlabstorage.blob.core.windows.net/logros/Visionary.webp",
+                            valorMax: 2,
+                        },
+                        {
+                            idLogro: 7,
+                            nombre: "Priority Achiever",
+                            descripcion:
+                                "Alcanza un puntaje de prioridad de al menos 500 puntos en una ocasión.",
+                            prioridadOtorgada: 1,
+                            color: "#F8E478",
+                            iconoURL:
+                                "https://dreamlabstorage.blob.core.windows.net/logros/PriorityAchiever.webp",
+                            valorMax: 500,
+                        },
+                        {
+                            idLogro: 8,
+                            nombre: "Five-Star Player",
+                            descripcion:
+                                "Forma parte del top 5 de usuarios con mayor prioridad.",
+                            prioridadOtorgada: 1,
+                            color: "#A0DE83",
+                            iconoURL:
+                                "https://dreamlabstorage.blob.core.windows.net/logros/Trustworthy.webp",
+                            valorMax: 1,
+                        },
+                        {
+                            idLogro: 9,
+                            nombre: "Communicator",
+                            descripcion:
+                                "Utiliza 1 vez el sistema de recomendaciones por voz.",
+                            prioridadOtorgada: 1,
+                            color: "#FEA767",
+                            iconoURL:
+                                "https://dreamlabstorage.blob.core.windows.net/logros/Communicator.webp",
+                            valorMax: 1,
+                        },
+                        {
+                            idLogro: 10,
+                            nombre: "Artistic Alchemist",
+                            descripcion:
+                                "Cambia tu icono de perfil por primera vez.",
+                            prioridadOtorgada: 1,
+                            color: "#FFCCCC",
+                            iconoURL:
+                                "https://dreamlabstorage.blob.core.windows.net/logros/ArtisticAlchemist.webp",
+                            valorMax: 1,
+                        },
+                    ],
+                    [
+                        { idLogro: 1, valorActual: 0, obtenido: false },
+                        { idLogro: 2, valorActual: 5, obtenido: false },
+                        { idLogro: 3, valorActual: 5, obtenido: true },
+                        { idLogro: 4, valorActual: 3, obtenido: false },
+                        { idLogro: 5, valorActual: 3, obtenido: true },
+                        { idLogro: 6, valorActual: 1, obtenido: false },
+                        { idLogro: 7, valorActual: 367, obtenido: false },
+                        { idLogro: 8, valorActual: 1, obtenido: true },
+                        { idLogro: 9, valorActual: 0, obtenido: false },
+                        { idLogro: 10, valorActual: 1, obtenido: true },
+                    ],
+                ],
+                recordset: [
+                    {
+                        prioridad: 55,
+                        nombre: "test",
+                        apellidoP: "test",
+                        apellidoM: "test",
+                        apodo: "Ancient Soul",
+                        iconoURL:
+                            "https://dreamlabstorage.blob.core.windows.net/logros/AncientSoul.webp",
+                    },
+                ],
+                output: {},
+                rowsAffected: [],
+            },
+        }).as("getPerfil");
+
+        cy.intercept("GET", "perfil/logros/test", {
+            logros: [
+                {
+                    idLogro: 1,
+                    nombre: "Big Dreamer",
+                    iconoURL:
+                        "https://dreamlabstorage.blob.core.windows.net/logros/BigDreamer.webp",
+                },
+                {
+                    idLogro: 3,
+                    nombre: "Robot Expert",
+                    iconoURL:
+                        "https://dreamlabstorage.blob.core.windows.net/logros/RobotExpert.webp",
+                },
+                {
+                    idLogro: 5,
+                    nombre: "Ancient Soul",
+                    iconoURL:
+                        "https://dreamlabstorage.blob.core.windows.net/logros/AncientSoul.webp",
+                },
+                {
+                    idLogro: 8,
+                    nombre: "Five-Star Player",
+                    iconoURL:
+                        "https://dreamlabstorage.blob.core.windows.net/logros/Trustworthy.webp",
+                },
+                {
+                    idLogro: 10,
+                    nombre: "Artistic Alchemist",
+                    iconoURL:
+                        "https://dreamlabstorage.blob.core.windows.net/logros/ArtisticAlchemist.webp",
+                },
+            ],
+            configuracionLogro: [
+                {
+                    idLogro: 5,
+                    nombre: "Ancient Soul",
+                    iconoURL:
+                        "https://dreamlabstorage.blob.core.windows.net/logros/AncientSoul.webp",
+                    colorPreferido: "#FF6073",
+                },
+            ],
+        }).as("getLogros");
+
+        cy.loginWith("test");
+        cy.visit("/profile");
+    });
+
+    it("Modificar icono y color de logro", () => {
+        cy.wait("@getPerfil");
+        cy.wait("@getLogros");
+    });
+});

--- a/dream-lab-frontend/cypress/e2e/personalizacionLogros.cy.js
+++ b/dream-lab-frontend/cypress/e2e/personalizacionLogros.cy.js
@@ -390,5 +390,9 @@ describe("Pruebas de personalización de los logros", () => {
     it("Modificar icono y color de logro", () => {
         cy.wait("@getPerfil");
         cy.wait("@getLogros");
+        cy.clickDataCy("boton-logro-perfil");
+        cy.containsDataCy("selector-logro-titulo", "Ancient Soul");
+        cy.clickDataCyNth("selector-logro-container", 1);
+        cy.containsDataCy("selector-logro-titulo", "Robot Expert");
     });
 });

--- a/dream-lab-frontend/cypress/e2e/personalizacionLogros.cy.js
+++ b/dream-lab-frontend/cypress/e2e/personalizacionLogros.cy.js
@@ -383,16 +383,70 @@ describe("Pruebas de personalización de los logros", () => {
             ],
         }).as("getLogros");
 
+        // Iniciar sesion con test
         cy.loginWith("test");
+        // Visitar el perfil
         cy.visit("/profile");
-    });
 
-    it("Modificar icono y color de logro", () => {
+        // Esperar a que se carguen los datos que se interceptaron
         cy.wait("@getPerfil");
         cy.wait("@getLogros");
+    });
+
+    it("Comprobar visualización de logro en perfil", () => {
+        // Checa que exista el boton para modificar y desplegar el logro del usuario
+        cy.getDataCy("boton-logro-perfil").should("exist");
+        // Checa que el logro del usuario tenga el icono correcto
+        cy.findDataCy("boton-logro-perfil", "icono-logro").hasAttribute(
+            "src",
+            "https://dreamlabstorage.blob.core.windows.net/logros/AncientSoul.webp"
+        );
+        // Checa que el logro del usuario tenga el color correcto
+        cy.findDataCy("boton-logro-perfil", "contenedor-icono-logro").hasStyle(
+            "background-color",
+            "rgb(255, 96, 115)"
+        );
+        // Checa que la tarjeta con el nombre del usuario tenga el titulo correcto
+        cy.containsDataCy("namecard-titulo-logro", "Ancient Soul");
+    });
+
+    it("Modificar icono de logro", () => {
+        // Boton para modificar el logro
         cy.clickDataCy("boton-logro-perfil");
+        // Checa el titulo del logro seleccionado en el modal
         cy.containsDataCy("selector-logro-titulo", "Ancient Soul");
+        // Checa el icono del logro seleccionado en el modal
+        cy.findDataCy("selector-logro-modal-icon", "icono-logro").hasAttribute(
+            "src",
+            "https://dreamlabstorage.blob.core.windows.net/logros/AncientSoul.webp"
+        );
+        // Selecciona otro logro de la lista de los logros disponibles
         cy.clickDataCyNth("selector-logro-container", 1);
+        // Checa el titulo del logro seleccionado en el modal
         cy.containsDataCy("selector-logro-titulo", "Robot Expert");
+        // Checa el icono del logro seleccionado en el modal
+        cy.findDataCy("selector-logro-modal-icon", "icono-logro").hasAttribute(
+            "src",
+            "https://dreamlabstorage.blob.core.windows.net/logros/RobotExpert.webp"
+        );
+    });
+
+    it("Modificar color de logro", () => {
+        // Boton para modificar el logro
+        cy.clickDataCy("boton-logro-perfil");
+        // Checa el color del logro seleccionado en el modal
+        cy.findDataCy(
+            "selector-logro-modal-icon",
+            "contenedor-icono-logro"
+        ).hasStyle("background-color", "rgb(255, 96, 115)");
+        // Presiona el boton para desplegar los colores disponibles
+        cy.clickDataCy("boton-selector-color");
+        // Selecciona un color de la lista de colores disponibles
+        cy.clickDataCyNth("selector-color-grid", 1);
+        // Checa el color del logro seleccionado en el modal
+        cy.findDataCy(
+            "selector-logro-modal-icon",
+            "contenedor-icono-logro"
+        ).hasStyle("background-color", "rgb(120, 194, 248)");
     });
 });

--- a/dream-lab-frontend/cypress/support/commands.js
+++ b/dream-lab-frontend/cypress/support/commands.js
@@ -33,6 +33,11 @@ Cypress.Commands.add("getDataCy", (name) => {
     return cy.get(`[data-cy=${name}]`);
 });
 
+// Encuentra un elemento hijo de un elemento con el atributo data-cy
+Cypress.Commands.add("findDataCy", (name, child) => {
+    return cy.getDataCy(name).find(`[data-cy=${child}]`);
+});
+
 // Obtiene el nth hijo dentro del componente con el atributo data-cy
 Cypress.Commands.add("getDataCyNth", (name, n) => {
     return cy.getDataCy(name).children().eq(n);
@@ -59,6 +64,15 @@ Cypress.Commands.add(
     { prevSubject: "element" },
     (subject, attr, value) => {
         return cy.wrap(subject).should("have.attr", attr, value);
+    }
+);
+
+// Verifica si un elemento tiene un estilo de css con un valor específico
+Cypress.Commands.add(
+    "hasStyle",
+    { prevSubject: "element" },
+    (subject, style, value) => {
+        return cy.wrap(subject).should("have.css", style, value);
     }
 );
 

--- a/dream-lab-frontend/cypress/support/commands.js
+++ b/dream-lab-frontend/cypress/support/commands.js
@@ -33,9 +33,19 @@ Cypress.Commands.add("getDataCy", (name) => {
     return cy.get(`[data-cy=${name}]`);
 });
 
+// Obtiene el nth hijo dentro del componente con el atributo data-cy
+Cypress.Commands.add("getDataCyNth", (name, n) => {
+    return cy.getDataCy(name).children().eq(n);
+});
+
 // Hace click en un elemento por el atributo data-cy
 Cypress.Commands.add("clickDataCy", (name) => {
     return cy.getDataCy(name).click();
+});
+
+// Hace click en el hijo nth de un elemento con el atributo data-cy
+Cypress.Commands.add("clickDataCyNth", (name, n) => {
+    return cy.getDataCyNth(name, n).click();
 });
 
 // Escribe en un elemento por el atributo data-cy
@@ -58,14 +68,6 @@ Cypress.Commands.add("containsDataCy", (name, text, timeout) => {
         timeout = 4000;
     }
     return cy.getDataCy(name).contains(text, { timeout: timeout });
-});
-
-// Checa si un elemento con el atributo data-cy contiene un texto específico
-Cypress.Commands.add("containsDataCy_Alt", (name, text) => {
-    return cy.getDataCy(name).then(($elemento) => {
-        const texto = $elemento.text();
-        expect(texto).to.equal(text);
-    });
 });
 
 // Iniciar sesión con usuario y contraseña

--- a/dream-lab-frontend/src/GlobalComponents/NuevoIconoLogro/NuevoIconoLogro.jsx
+++ b/dream-lab-frontend/src/GlobalComponents/NuevoIconoLogro/NuevoIconoLogro.jsx
@@ -6,8 +6,14 @@ function NuevoIconoLogro({ icono, colorFondo }) {
         <div
             className={`ic-contenedor-logro`}
             style={{ "--color-fondo": colorFondo }}
+            data-cy="contenedor-icono-logro"
         >
-            <img className="ic-icono-logro" src={icono} alt="Icono del logro" />
+            <img
+                className="ic-icono-logro"
+                src={icono}
+                alt="Icono del logro"
+                data-cy="icono-logro"
+            />
         </div>
     );
 }

--- a/dream-lab-frontend/src/pages/Profile/components/NameCard/NameCard.jsx
+++ b/dream-lab-frontend/src/pages/Profile/components/NameCard/NameCard.jsx
@@ -19,8 +19,9 @@ function NameCard({ nombre, handleLogroArtista }) {
     const [logrosObtenidos, setLogrosObtenidos] = useState([]);
     const [logroSeleccionado, setLogroSeleccionado] = useState({});
     const [colorSeleccionado, setColorSeleccionado] = useState("");
-    const [refresh, setRefresh] = useState(false);
 
+    // Obtener los logros del usuario, el logro seleccionado y el color
+    // seleccionado de su preferencia cada que se carga la página
     useEffect(() => {
         get(`perfil/logros/${getFromLocalStorage("user")}`).then((response) => {
             setLogrosObtenidos(response.logros);
@@ -31,12 +32,11 @@ function NameCard({ nombre, handleLogroArtista }) {
             });
             setColorSeleccionado(response.configuracionLogro[0].colorPreferido);
         });
-    }, [refresh]);
+    }, []);
 
     return (
         <div className="div-exterior">
             <BotonLogroPerfil
-                setRefresh={setRefresh}
                 colorSeleccionado={colorSeleccionado}
                 setColorSeleccionado={setColorSeleccionado}
                 logrosObtenidos={logrosObtenidos}

--- a/dream-lab-frontend/src/pages/Profile/components/NameCard/NameCard.jsx
+++ b/dream-lab-frontend/src/pages/Profile/components/NameCard/NameCard.jsx
@@ -46,7 +46,7 @@ function NameCard({ nombre, handleLogroArtista }) {
             />
             <div className="div-usuario">
                 <h1 className="nombre-usuario">{nombre}</h1>
-                <h2 className="apodo">{logroSeleccionado.nombre}</h2>
+                <h2 className="apodo" data-cy="namecard-titulo-logro">{logroSeleccionado.nombre}</h2>
             </div>
         </div>
     );

--- a/dream-lab-frontend/src/pages/Profile/components/NameCard/components/BotonLogroPerfil/BotonLogroPerfil.jsx
+++ b/dream-lab-frontend/src/pages/Profile/components/NameCard/components/BotonLogroPerfil/BotonLogroPerfil.jsx
@@ -12,7 +12,6 @@ import NuevoIconoLogro from "src/GlobalComponents/NuevoIconoLogro/NuevoIconoLogr
 import propTypes from "prop-types";
 
 function IconoLogroPerfil({
-    setRefresh,
     colorSeleccionado,
     setColorSeleccionado,
     logrosObtenidos,
@@ -22,17 +21,13 @@ function IconoLogroPerfil({
 }) {
     const { isOpen, onOpen, onOpenChange } = useDisclosure();
 
-    const abrirSelector = () => {
-        onOpenChange();
-    };
-
     return (
         <>
-            <div className="ilp-logo-div" onClick={abrirSelector}>
+            <div className="ilp-logo-div">
                 <Button
                     isIconOnly
                     className="h-full w-full bg-transparent"
-                    onPress={abrirSelector}
+                    onPress={() => onOpenChange()}
                 >
                     <NuevoIconoLogro
                         icono={logroSeleccionado.iconoURL}
@@ -44,7 +39,6 @@ function IconoLogroPerfil({
                 isOpen={isOpen}
                 onOpen={onOpen}
                 onOpenChange={onOpenChange}
-                setRefresh={setRefresh}
                 colorSeleccionado={colorSeleccionado}
                 setColorSeleccionado={setColorSeleccionado}
                 logrosObtenidos={logrosObtenidos}
@@ -57,7 +51,6 @@ function IconoLogroPerfil({
 }
 
 IconoLogroPerfil.propTypes = {
-    setRefresh: propTypes.func,
     colorSeleccionado: propTypes.string,
     setColorSeleccionado: propTypes.func,
     logrosObtenidos: propTypes.array,

--- a/dream-lab-frontend/src/pages/Profile/components/NameCard/components/BotonLogroPerfil/BotonLogroPerfil.jsx
+++ b/dream-lab-frontend/src/pages/Profile/components/NameCard/components/BotonLogroPerfil/BotonLogroPerfil.jsx
@@ -28,6 +28,7 @@ function IconoLogroPerfil({
                     isIconOnly
                     className="h-full w-full bg-transparent"
                     onPress={() => onOpenChange()}
+                    data-cy="boton-logro-perfil"
                 >
                     <NuevoIconoLogro
                         icono={logroSeleccionado.iconoURL}

--- a/dream-lab-frontend/src/pages/Profile/components/NameCard/components/BotonLogroPerfil/components/SelectorLogro/SelectorLogro.jsx
+++ b/dream-lab-frontend/src/pages/Profile/components/NameCard/components/BotonLogroPerfil/components/SelectorLogro/SelectorLogro.jsx
@@ -15,7 +15,7 @@ import NuevoIconoLogro from "src/GlobalComponents/NuevoIconoLogro/NuevoIconoLogr
 import SelectorLogroItem from "./components/SelectorLogroItem/SelectorLogroItem";
 
 // API Requests
-import { get, post } from "src/utils/ApiRequests";
+import { post } from "src/utils/ApiRequests";
 
 // Local Storage
 import { getFromLocalStorage } from "src/utils/Storage";
@@ -25,7 +25,6 @@ function SelectorLogro({
     isOpen,
     onOpen,
     onOpenChange,
-    setRefresh,
     colorSeleccionado,
     setColorSeleccionado,
     logrosObtenidos,
@@ -33,46 +32,78 @@ function SelectorLogro({
     setLogroSeleccionado,
     handleLogroArtista,
 }) {
+    const [logroPreSeleccionado, setLogroPreSeleccionado] = useState({});
+    const [colorPreSeleccionado, setColorPreSeleccionado] = useState("");
+
+    // Obtenemos los valores originales del logro y color seleccionado como
+    // valor incial de la preseleccion
+    useEffect(() => {
+        setLogroPreSeleccionado(logroSeleccionado);
+        setColorPreSeleccionado(colorSeleccionado);
+    }, [logroSeleccionado, colorSeleccionado]);
+
+    // Guarda el logro y color seleccionado en la base de datos
     const handleSave = async () => {
+        setLogroSeleccionado(logroPreSeleccionado);
+        setColorSeleccionado(colorPreSeleccionado);
+
         try {
             const response = await post(
                 `perfil/logros/${getFromLocalStorage("user")}`,
                 {
-                    idLogro: logroSeleccionado.idLogro,
-                    colorPreferido: colorSeleccionado,
+                    idLogro: logroPreSeleccionado.idLogro,
+                    colorPreferido: colorPreSeleccionado,
                 }
             );
+            // Otorga un logro por customizar el perfil
             await handleLogroArtista(10);
-            setRefresh((prev) => !prev);
+            // Cierra el modal
             onOpenChange();
         } catch (error) {
             console.error(error);
         }
     };
 
+    // En caso de cerrar el modal, se regresan los valores a los originales
+    const handleClose = () => {
+        setLogroPreSeleccionado(logroSeleccionado);
+        setColorPreSeleccionado(colorSeleccionado);
+    };
+
     return (
-        <Modal isOpen={isOpen} onOpenChange={onOpenChange} size="5xl">
+        <Modal
+            isOpen={isOpen}
+            onOpenChange={(isOpen) => {
+                if (!isOpen) {
+                    handleClose();
+                }
+                onOpenChange(isOpen);
+            }}
+            size="5xl"
+        >
             <ModalContent>
                 <ModalBody>
                     <div className="sl-main-container">
                         <div className="sl-left-container">
                             <div className="sl-title-container">
                                 <h1 className="sl-title">
-                                    {logroSeleccionado.nombre}
+                                    {logroPreSeleccionado.nombre}
                                 </h1>
                             </div>
                             <div className="sl-icon-container">
                                 <div className="sl-icon">
                                     <NuevoIconoLogro
-                                        icono={logroSeleccionado.iconoURL}
-                                        colorFondo={colorSeleccionado}
+                                        icono={logroPreSeleccionado.iconoURL}
+                                        colorFondo={colorPreSeleccionado}
                                     />
                                 </div>
                             </div>
                             <div className="sl-color-button-container">
                                 <SelectorColores
-                                    colorSeleccionado={colorSeleccionado}
-                                    setColorSeleccionado={setColorSeleccionado}
+                                    colorSeleccionado={colorPreSeleccionado}
+                                    setColorSeleccionado={
+                                        setColorPreSeleccionado
+                                    }
                                 />
                             </div>
                         </div>
@@ -84,13 +115,13 @@ function SelectorLogro({
                                         <SelectorLogroItem
                                             logro={logro}
                                             setLogroSeleccionado={
-                                                setLogroSeleccionado
+                                                setLogroPreSeleccionado
                                             }
                                             selected={
                                                 logro.idLogro ===
-                                                logroSeleccionado.idLogro
+                                                logroPreSeleccionado.idLogro
                                             }
-                                            selectedColor={colorSeleccionado}
+                                            selectedColor={colorPreSeleccionado}
                                         />
                                     </div>
                                 ))}
@@ -121,7 +152,6 @@ SelectorLogro.propTypes = {
     isOpen: PropTypes.bool,
     onOpen: PropTypes.func,
     onOpenChange: PropTypes.func,
-    setRefresh: PropTypes.func,
     colorSeleccionado: PropTypes.string,
     setColorSeleccionado: PropTypes.func,
     logrosObtenidos: PropTypes.array,

--- a/dream-lab-frontend/src/pages/Profile/components/NameCard/components/BotonLogroPerfil/components/SelectorLogro/SelectorLogro.jsx
+++ b/dream-lab-frontend/src/pages/Profile/components/NameCard/components/BotonLogroPerfil/components/SelectorLogro/SelectorLogro.jsx
@@ -86,7 +86,7 @@ function SelectorLogro({
                     <div className="sl-main-container">
                         <div className="sl-left-container">
                             <div className="sl-title-container">
-                                <h1 className="sl-title">
+                                <h1 className="sl-title" data-cy='selector-logro-titulo'>
                                     {logroPreSeleccionado.nombre}
                                 </h1>
                             </div>
@@ -109,7 +109,7 @@ function SelectorLogro({
                         </div>
                         <div className="sl-center-container"></div>
                         <div className="sl-right-container">
-                            <div className="sl-opciones-logros-container">
+                            <div className="sl-opciones-logros-container" data-cy='selector-logro-container'>
                                 {logrosObtenidos.map((logro, index) => (
                                     <div key={index} className="sl-logro-item">
                                         <SelectorLogroItem

--- a/dream-lab-frontend/src/pages/Profile/components/NameCard/components/BotonLogroPerfil/components/SelectorLogro/SelectorLogro.jsx
+++ b/dream-lab-frontend/src/pages/Profile/components/NameCard/components/BotonLogroPerfil/components/SelectorLogro/SelectorLogro.jsx
@@ -91,7 +91,7 @@ function SelectorLogro({
                                 </h1>
                             </div>
                             <div className="sl-icon-container">
-                                <div className="sl-icon">
+                                <div className="sl-icon" data-cy='selector-logro-modal-icon'>
                                     <NuevoIconoLogro
                                         icono={logroPreSeleccionado.iconoURL}
                                         colorFondo={colorPreSeleccionado}

--- a/dream-lab-frontend/src/pages/Profile/components/NameCard/components/BotonLogroPerfil/components/SelectorLogro/components/SelectorLogroItem/SelectorColores/SelectorColores.jsx
+++ b/dream-lab-frontend/src/pages/Profile/components/NameCard/components/BotonLogroPerfil/components/SelectorLogro/components/SelectorLogroItem/SelectorColores/SelectorColores.jsx
@@ -57,6 +57,7 @@ function SelectorColores({ colorSeleccionado, setColorSeleccionado }) {
                     onPress={() => {
                         setIsOpen(true);
                     }}
+                    data-cy="boton-selector-color"
                 >
                     <span className="sc-color-button-text">Cambiar color</span>
                 </Button>
@@ -64,7 +65,7 @@ function SelectorColores({ colorSeleccionado, setColorSeleccionado }) {
             <PopoverContent>
                 {() => (
                     <div className="sc-cologrid-container">
-                        <div className="sc-colorgrid">
+                        <div className="sc-colorgrid" data-cy="selector-color-grid">
                             {colors.map((color, index) => (
                                 <Button
                                     key={index}

--- a/dream-lab-frontend/src/pages/Profile/components/NameCard/components/BotonLogroPerfil/components/SelectorLogro/components/SelectorLogroItem/SelectorLogroItem.jsx
+++ b/dream-lab-frontend/src/pages/Profile/components/NameCard/components/BotonLogroPerfil/components/SelectorLogro/components/SelectorLogroItem/SelectorLogroItem.jsx
@@ -16,16 +16,13 @@ function SelectorLogroItem({
     setLogroSeleccionado,
     selectedColor,
 }) {
-    const handleClick = () => {
-        setLogroSeleccionado(logro);
-    };
     const className = selected
         ? "sli-logro-item-icon sli-selected"
         : "sli-logro-item-icon";
     return (
         <div
             className={className}
-            onClick={handleClick}
+            onClick={() => setLogroSeleccionado(logro)}
             style={{ borderColor: selectedColor }}
         >
             <NuevoIconoLogro icono={logro.iconoURL} />

--- a/dream-lab-frontend/src/pages/Profile/components/NameCard/components/BotonLogroPerfil/components/SelectorLogro/components/SelectorLogroItem/SelectorLogroItem.jsx
+++ b/dream-lab-frontend/src/pages/Profile/components/NameCard/components/BotonLogroPerfil/components/SelectorLogro/components/SelectorLogroItem/SelectorLogroItem.jsx
@@ -7,9 +7,6 @@ import "./SelectorLogroItem.css";
 // Proptypes
 import PropTypes from "prop-types";
 
-// Nextui components
-import { Button } from "@nextui-org/react";
-
 function SelectorLogroItem({
     logro,
     selected,


### PR DESCRIPTION
## Descripción de cambios
- Corregir que el logro seleccionado en el modal, que todavía no se guarda en la base de datos, no sea el mismo que se está desplegando en el perfil. Esto ocasionaba que incluso si se cancelaba la operación (se cerraba el modal), el perfil desplegara el logro seleccionado, pero al recargar la página, se desplegaba nuevamente el guardado, por lo que era inconsistente. Se agrego una variable para la preselección.
- Limpiar código.
- Prevenir llamadas innecesarias a la base de datos. Anteriormente, cada vez que se modificaba el logro, se forzaba una llamada a la base de datos para actualizar el perfil con los datos que se acababan de guardar. Esto no tenía sentido considerando que los datos nuevos ya estaban localmente. Ahora solo se hace la petición cuando recién se carga la página de perfil. Cuando se guarda la personalización del logro se actualiza un useState del logro que se despliega, por lo que ya se visualiza lo más nuevo.
- Restaurar al logro guardado al abrir el modal de customización en caso de que se llegue a cerrar el modal sin guardar los cambios.
- Agregar pruebas de cypress para comprobar funcionalidad de selector de logros.

## Lista de Verificación
- [X] Agregué comentarios a mi código.
- [X] Mis cambios no generan ninguna alerta.
- [X] El flujo desarrollado cuenta con pruebas de Cypress.
- [X] Todas las pruebas de Cypress pasaron.
- [X] Construí y previsualicé la aplicación y la nueva funcionalidad se despliega correctamente.
