### PR TITLE
Quitar guardado de 0 como id que rompia FK en base de datos

### DIFF
--- a/dream-lab-frontend/src/pages/HomePage/components/Detalles/Detalles.jsx
+++ b/dream-lab-frontend/src/pages/HomePage/components/Detalles/Detalles.jsx
@@ -30,9 +30,10 @@ function ExperienceDetails(props) {
         // Llama a la función de navegación pasada como prop
         saveToSessionStorage("reservType", selectedItem.type);
 
-        if (selectedItem.type == "sala") {
+        if (selectedItem.type === "sala") {
             saveToSessionStorage("idSala", selectedItem.id);
-            saveToSessionStorage("idExperiencia", 0);
+            // TODO: @Reynaldo revisar si es necesario guardar 0 en idExperiencia
+            // saveToSessionStorage("idExperiencia", 0);
         } else {
             saveToSessionStorage("idExperiencia", selectedItem.id);
         }


### PR DESCRIPTION
## Descripción de cambios
- Remover guardado de 0 como idExperiencia en sessionStorage que hacia que al postear una nueva reservación, hubiera un problema con las FK porque no existe experiencia con id 0.
